### PR TITLE
Port over config changes from upstream that apply to our version of

### DIFF
--- a/attributes/carbon_cache.rb
+++ b/attributes/carbon_cache.rb
@@ -19,6 +19,8 @@ default['graphite']['carbon']['max_creates_per_minute'] = 'inf'
 default['graphite']['carbon']['max_updates_per_second'] = '1000'
 default['graphite']['carbon']['log_whisper_updates'] = 'False'
 default['graphite']['carbon']['whisper_autoflush'] = 'False'
+default['graphite']['carbon']['max_updates_per_second_on_shutdown'] = '2000'
+default['graphite']['carbon']['cache_write_stategy'] = 'sorted'
 
 default['graphite']['storage_schemas'] = [
   {

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -41,6 +41,7 @@ default['graphite']['web']['admin_email'] = 'admin@org.com'
 default['graphite']['web']['cluster_servers'] = []
 default['graphite']['web']['carbonlink_hosts'] = []
 default['graphite']['web']['memcached_hosts'] = ['127.0.0.1:11211']
+default['graphite']['web']['memcached_seconds'] = 60
 default['graphite']['web']['database']['NAME'] = node['graphite']['storage_dir'] + '/graphite.db'
 default['graphite']['web']['database']['ENGINE'] = 'django.db.backends.sqlite3'
 default['graphite']['web']['database']['USER'] = ''

--- a/recipes/web.rb
+++ b/recipes/web.rb
@@ -79,7 +79,8 @@ template "/etc/graphite/local_settings.py" do
             :ldap => node['graphite']['web']['ldap'],
             :remote_user_auth => node['graphite']['web']['auth']['REMOTE_USER_AUTH'],
             :login_url => node['graphite']['web']['auth']['LOGIN_URL'],
-            :email => node['graphite']['web']['email'])
+            :email => node['graphite']['web']['email'],
+            :memcached_seconds => node['graphite']['web']['memcached_seconds'])
   notifies :reload, graphite_web_service_resource
 end
 

--- a/templates/default/carbon.conf.erb
+++ b/templates/default/carbon.conf.erb
@@ -56,6 +56,13 @@ MAX_UPDATES_PER_SECOND = <%= @carbon_options[:max_updates_per_second] %>
 # the files quickly but at the risk of slowing I/O down considerably for a while.
 MAX_CREATES_PER_MINUTE = <%= @carbon_options[:max_creates_per_minute] %>
 
+
+# If defined, this changes the MAX_UPDATES_PER_SECOND in Carbon when a
+# stop/shutdown is initiated.  This helps when MAX_UPDATES_PER_SECOND is
+# relatively low and carbon has cached a lot of updates; it enables the carbon
+# daemon to shutdown more quickly.
+MAX_UPDATES_PER_SECOND_ON_SHUTDOWN =  <%= @carbon_options[:max_updates_per_second_on_shutdown] %>
+
 LINE_RECEIVER_INTERFACE = <%= @carbon_options[:caches][:a][:line_receiver_interface] %>
 LINE_RECEIVER_PORT = <%= @carbon_options[:caches][:a][:line_receiver_port] %>
 
@@ -83,9 +90,36 @@ CACHE_QUERY_PORT = <%= @carbon_options[:caches][:a][:cache_query_port] %>
 # data until the cache size falls below 95% MAX_CACHE_SIZE.
 USE_FLOW_CONTROL = <%= @carbon_options[:use_flow_control] %>
 
-# By default, carbon-cache will log every whisper update. This can be excessive and
+# By default, carbon-cache will log every whisper update and cache hit. This can be excessive and
 # degrade performance if logging on the same volume as the whisper data is stored.
 LOG_UPDATES = <%= @carbon_options[:log_whisper_updates] %>
+LOG_CACHE_HITS = False
+LOG_CACHE_QUEUE_SORTS = True
+
+# The thread that writes metrics to disk can use on of the following strategies
+# determining the order in which metrics are removed from cache and flushed to
+# disk. The default option preserves the same behavior as has been historically
+# available in version 0.9.10.
+#
+# sorted - All metrics in the cache will be counted and an ordered list of
+# them will be sorted according to the number of datapoints in the cache at the
+# moment of the list's creation. Metrics will then be flushed from the cache to
+# disk in that order.
+#
+# max - The writer thread will always pop and flush the metric from cache
+# that has the most datapoints. This will give a strong flush preference to
+# frequently updated metrics and will also reduce random file-io. Infrequently
+# updated metrics may only ever be persisted to disk at daemon shutdown if
+# there are a large number of metrics which receive very frequent updates OR if
+# disk i/o is very slow.
+#
+# naive - Metrics will be flushed from the cache to disk in an unordered
+# fashion. This strategy may be desirable in situations where the storage for
+# whisper files is solid state, CPU resources are very limited or deference to
+# the OS's i/o scheduler is expected to compensate for the random write
+# pattern.
+#
+CACHE_WRITE_STRATEGY = <%= @carbon_options[:cache_write_stategy] %>
 
 # On some systems it is desirable for whisper to write synchronously.
 # Set this option to True if you'd like to try this. Basically it will
@@ -99,6 +133,14 @@ WHISPER_AUTOFLUSH = <%= @carbon_options[:whisper_autoflush] %>
 # MAX_CREATES_PER_MINUTE but may have longer term performance implications
 # depending on the underlying storage configuration.
 # WHISPER_SPARSE_CREATE = False
+
+# Only beneficial on linux filesystems that support the fallocate system call.
+# It maintains the benefits of contiguous reads/writes, but with a potentially
+# much faster creation speed, by allowing the kernel to handle the block
+# allocation and zero-ing. Enabling this option may allow a large increase of
+# MAX_CREATES_PER_MINUTE. If enabled on an OS or filesystem that is unsupported
+# this option will gracefully fallback to standard POSIX file access methods.
+WHISPER_FALLOCATE_CREATE = True
 
 # Enabling this option will cause Whisper to lock each Whisper file it writes
 # to with an exclusive lock (LOCK_EX, see: man 2 flock). This is useful when

--- a/templates/default/local_settings.py.erb
+++ b/templates/default/local_settings.py.erb
@@ -26,20 +26,21 @@ DEBUG = <%= @debug %>
 #FLUSHRRDCACHED = 'unix:/var/run/rrdcached.sock'
 
 # This lists the memcached servers that will be used by this webapp.
-# If you have a cluster of webapps you should ensure all of them
-# have the *exact* same value for this setting. That will maximize cache
-# efficiency. Setting MEMCACHE_HOSTS to be empty will turn off use of
-# memcached entirely.
-#
-# You should not use the loopback address (127.0.0.1) here if using clustering
-# as every webapp in the cluster should use the exact same values to prevent
-# unneeded cache misses. Set to [] to disable caching of images and fetched data
-MEMCACHE_HOSTS = [ <%= @memcached_hosts.map do |server|
-  "\"#{server}\""
+# In Graphite 0.9.12 they reference memcache incorrectly with Django 1.3+
+# This will set memcache manually until the next version is available
+# in linux.
+
+<% if @memcached_hosts -%>
+CACHE_MIDDLEWARE_SECONDS = <%= @memcached_seconds %>
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'LOCATION': [<%= @memcached_hosts.map do |server|
+  "'#{server}'"
 end.join(', ') %> ]
-
-#DEFAULT_CACHE_DURATION = 60 # Cache images and data for 1 minute
-
+    }
+}
+<% end -%>
 
 #####################################
 # Filesystem Paths #


### PR DESCRIPTION
graphite.

* Use memcached correctly
* Be able to pick a write strat
* Allow for OS specific configs to be turned on

These changes are based on reading the Django docs
and from the generated config template included with the version
of graphite we use.

@austinmills @vitroth @tmlink 