### PR TITLE
Increase the restart timeout for carbon cache

### DIFF
--- a/recipes/carbon_cache_runit.rb
+++ b/recipes/carbon_cache_runit.rb
@@ -25,6 +25,7 @@ node['graphite']['carbon']['caches'].each do |key,data|
     log_template_name 'carbon'
     finish_script_template_name 'carbon'
     finish true
+    sv_timeout 60
     default_logger    true
     options(:name => "cache", :instance => key)
     subscribes :restart, "template[#{node['graphite']['base_dir']}/conf/carbon.conf]"


### PR DESCRIPTION
We have slowed down the disk writes for carbon-cache-a on some clusters.  This
causes the restarts of carbon cache to take longer then the 7 second timeout
currently set, which is the default timeout for runit.  This change sets the
timeout from the default 7 seconds to 60 seconds for the carbon caches.

Resolves: SRE-399
Reviewer: @vitroth 

### Test Methodology
* Deployed a local microcHCOSm instance.
* Inserted a 30 second sleep in to the shutdown handler for carbon cache (/usr/lib/python2.7/dist-packages/carbon/writer.py in shutdownModifyUpdateSpeed)
* Deployed the current install and watched it failed.
* Update continuum-chef to include this fix.
* Deployed and watched the deploy complete and restart carbon cache.

**Note:** This will require an update to the Cheffile.lock in continuum-chef, which I will submit as a PR after this is merged.