### PR TITLE
Force restart of services when packages updated

### DIFF
--- a/recipes/carbon.rb
+++ b/recipes/carbon.rb
@@ -17,11 +17,25 @@
 # limitations under the License.
 #
 
+service_type = node['graphite']['carbon']['service_type']
+include_recipe "#{cookbook_name}::#{recipe_name}_cache_#{service_type}"
+
 package 'python-twisted'
 package 'python-simplejson'
 
-package "graphite-carbon" do
-  action :upgrade
+case service_type
+when 'runit'
+  package "graphite-carbon" do
+    action :upgrade
+    node['graphite']['carbon']['caches'].each do |key,data|
+      notifies :restart, "service[carbon-cache-#{key}]"
+    end
+  end
+else
+  package "graphite-carbon" do
+    action :upgrade
+    notifies :restart, 'service[carbon-cache]'
+  end
 end
 
 directory "#{node['graphite']['base_dir']}/conf" do

--- a/recipes/web.rb
+++ b/recipes/web.rb
@@ -37,7 +37,11 @@ else
 end
 
 package 'graphite-web' do
+  # The package is attempting to overwrite /etc/graphite/local_settings.py,
+  # which causes a conflict.  We want the old version.
+  options "-o Dpkg::Options::='--force-confold'"
   action :upgrade
+  notifies :restart, graphite_web_service_resource
 end
 
 directory "#{storagedir}/log/webapp" do


### PR DESCRIPTION
We need to restart the graphite-web and carbon-cache when we update
packages.  Otherwise, the services will be left running the old
code and will cause failures.

The graphite-web package needs to use --force-confold to stop
conflicts with /etc/graphite/local_settings.py.

JIRA: SRE-466
Reviewer: @austinmills 