### PR TITLE
Increase the time allowed to restart uwsgi

### DIFF
--- a/recipes/uwsgi_runit.rb
+++ b/recipes/uwsgi_runit.rb
@@ -3,7 +3,7 @@ include_recipe 'runit'
 runit_service 'graphite-web' do
   # uwsgi/graphite-web can sometimes be a tad slow to startup, so allow more
   # than the default 7 seconds for it load up.
-  sv_timeout 60
+  sv_timeout 120
   default_logger true
   restart_on_update false
 end


### PR DESCRIPTION
It is possible that uwsgi is taking longer to restart because
of either the new deb or performance in the testing env.  This
might be causing the tests to fail.  So, we are going to test
changing the timeout to 120 seconds to see if the intermittent
failures in the test env go away.

See also: SRE-466