### PR TITLE
ENGT-9213: graphite-web startup failure

### DIFF
--- a/recipes/uwsgi_runit.rb
+++ b/recipes/uwsgi_runit.rb
@@ -1,9 +1,11 @@
 include_recipe 'runit'
 
 runit_service 'graphite-web' do
-  # uwsgi/graphite-web can sometimes be a tad slow to startup, so allow more
-  # than the default 7 seconds for it load up.
-  sv_timeout 120
+  # Sometimes graphite-web starts, but runit fails to understand that it started,
+  # so timeout the startup after 10 seconds but try to start it at least 10 times.
+  sv_timeout 10
+  retries 10
+  retry_delay 2
   default_logger true
   restart_on_update false
 end


### PR DESCRIPTION
Sometimes graphite-web starts, but runit fails to understand that it started,
so timeout the startup after 10 seconds but try to start it at least 10 times.

Here is my change from July 18 that fixed the problem: https://github.com/apcera/continuum-chef/pull/988/files

Here is an update of the recipe from Tom Cahill that reintroduced the original code with the original problem: https://github.com/apcera/continuum-chef/commit/4bf8805e33c54e3ba474033fa0fe000583cf59fa

So basically my fix got overwritten because I added the change to `continuum-chef` and I should have added it to `chef-graphite`.
